### PR TITLE
[BUGFIX] Fix fatal error: GeneralUtility not found

### DIFF
--- a/Classes/ContentObject/ShockwaveFlashObjectContentObject.php
+++ b/Classes/ContentObject/ShockwaveFlashObjectContentObject.php
@@ -15,6 +15,7 @@ namespace FoT3\Mediace\ContentObject;
  */
 
 use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\StringUtility;
 
 /**


### PR DESCRIPTION
Add a missing use statement to prevent a fatal error when using
class GeneralUtility.